### PR TITLE
Fix FontAwesome icons by removing invalid integrity attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://ka-f.fontawesome.com" crossorigin>
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-SgOJa3DmI69IUzQ2PVdRZhwQ+dy64/BUtbMJw1MZ8t5HZApcHrRKUc4W0kG879m7" crossorigin="anonymous">
-    <script src="https://kit.fontawesome.com/aa30dc648a.js" crossorigin="anonymous" integrity="sha384-sNaC2hv7Q7nOh8J6JhBXdaK7fCJ4KDZr5OzUE3ovXJh9CJ1Lh7p0L7yNhPHfPKEt"></script>
+    <script src="https://kit.fontawesome.com/aa30dc648a.js" crossorigin="anonymous"></script>
 
     <style>
         .social { font-size: 3rem; }


### PR DESCRIPTION
FontAwesome Kit scripts are dynamically generated and don't support integrity hashes. The invalid integrity attribute was blocking the script from loading, causing icons to not display.

🤖 Generated with [Claude Code](https://claude.ai/code)