### PR TITLE
ci: skip Claude code review for dependency PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip dependency PRs (same rules as dependency auto-merge)
+    if: >
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      !(github.event.pull_request.user.login == 'jluszcz' && startsWith(github.event.pull_request.head.ref, 'Deps-'))
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Skip review for PRs that the dependency auto-merge would handle: opened by dependabot, or opened by jluszcz from a Deps-* branch. These are dependency-only changes that don't need code review.