### PR TITLE
ci: add Dependabot config for github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      all-actions:
+        patterns:
+          - "*"
+    assignees:
+      - "jluszcz"


### PR DESCRIPTION
Adds `.github/dependabot.yml` for the `github-actions` ecosystem.

This enables monthly GitHub Actions dependency PRs (grouped into a single `all-actions` group, assigned to jluszcz), matching the rest of the fleet. It brings this repo's stale workflow pins (e.g. `checkout@v6`) back under automated update coverage. A 7-day cooldown is applied before proposing updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)