### PR TITLE
ci: add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,11 @@
+name: Auto-Merge
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  auto-merge:
+    uses: jluszcz/github-utils/.github/workflows/auto-merge.yml@v1
+    secrets: inherit


### PR DESCRIPTION
Calls the reusable jluszcz/github-utils auto-merge workflow to enable squash auto-merge on Dependabot PRs.