### PR TITLE
Fix live site defects: content type, CloudFront invalidation, 403 assets

### DIFF
--- a/.github/workflows/minify-and-upload-to-s3.yml
+++ b/.github/workflows/minify-and-upload-to-s3.yml
@@ -37,4 +37,23 @@ jobs:
       - name: Upload to S3
         env:
           AWS_DEFAULT_REGION: us-east-1
-        run: aws s3 cp index.min s3://jluszcz.com/index.html
+        # index.min has no file extension, so the CLI infers no MIME type and
+        # defaults to binary/octet-stream. Set it explicitly.
+        run: aws s3 cp index.min s3://jluszcz.com/index.html --content-type "text/html; charset=utf-8"
+
+      - name: Invalidate CloudFront
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          # The cache TTLs are up to 24h, so without this a deploy is not live.
+          # Wait for completion so a green check means the new page is served.
+          invalidation_id="$(aws cloudfront create-invalidation \
+            --distribution-id "$DISTRIBUTION_ID" \
+            --paths '/*' \
+            --query 'Invalidation.Id' \
+            --output text)"
+
+          aws cloudfront wait invalidation-completed \
+            --distribution-id "$DISTRIBUTION_ID" \
+            --id "$invalidation_id"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md
+
+Single-page personal site: one hand-written `index.html` and `jluszcz.tf` for all
+the AWS infrastructure. There is no build system, no package.json, and no test
+suite — the only automated checks are `pre-commit` (see
+`.pre-commit-config.yaml`) and `terraform fmt`/`validate`.
+
+See `README.md` for the infrastructure overview and deploy steps.
+
+## The site is exactly one file
+
+`s3:PutObject` in `jluszcz.tf` is scoped to `${bucket}/index.html`, so adding a
+second file to the site — an image, a favicon, a manifest — requires widening
+that policy and running `terraform apply` *before* the deploy will succeed.
+Otherwise the upload fails with `AccessDenied`.
+
+The same ordering applies to any new AWS API the workflow calls: apply first,
+then merge.
+
+Because the bucket blocks public access and is readable only through
+CloudFront's OAC, a file `index.html` references but that was never uploaded
+returns **403, not 404**. Don't read that as a permissions bug.
+
+## Uploads must set `--content-type` explicitly
+
+The minified HTML is written to `index.min`, which has no file extension, so the
+AWS CLI infers no MIME type and defaults to `binary/octet-stream`. The page still
+renders — browsers sniff it — which is why this was wrong in production for a
+long time without anyone noticing, and why adding a `nosniff` header would have
+broken the site. `.github/workflows/minify-and-upload-to-s3.yml` passes
+`--content-type "text/html; charset=utf-8"`.
+
+## Every deploy invalidates CloudFront
+
+`default_ttl` is 24h and `min_ttl` is 1h, so without an invalidation a green
+deploy still serves the old page for up to a day. The workflow creates the
+invalidation and waits for it to complete, so a passing check means the change is
+actually live. It reads the distribution ID from the
+`CLOUDFRONT_DISTRIBUTION_ID` repository secret.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,30 @@ Managed with Terraform (state stored in S3 at `jluszcz-tf-state`):
 - **CloudFront** — CDN distribution with HTTPS redirect, HTTP/2+3, and OAC-based S3 access
 - **ACM** — TLS certificate for `jluszcz.com` and `www.jluszcz.com`
 - **Route 53** — hosted zone with A records for apex and `www`, plus a TXT record for Bluesky ATProto verification
-- **IAM** — OIDC-based GitHub Actions role scoped to `s3:PutObject` on `index.html`
+- **IAM** — OIDC-based GitHub Actions role scoped to `s3:PutObject` on `index.html`, plus invalidating the site's CloudFront distribution
 
 ## Deployment
 
-Pushing changes to `index.html` on `main` triggers the [Upload to S3](.github/workflows/upload-to-s3.yml) GitHub Actions workflow,
-which assumes an IAM role via OIDC and syncs the file to the S3 bucket.
+Pushing to `main` triggers the [Minify and Upload to S3](.github/workflows/minify-and-upload-to-s3.yml)
+workflow, which assumes an IAM role via OIDC, minifies `index.html`, uploads it
+to the bucket, and then invalidates the CloudFront distribution.
+
+Two things the deploy depends on:
+
+- **The upload sets `--content-type` explicitly.** The minified HTML is written
+  to `index.min`, which has no extension for the CLI to infer a MIME type from,
+  so without it the page is served as `binary/octet-stream` and only renders
+  because browsers sniff it.
+- **The `CLOUDFRONT_DISTRIBUTION_ID` repository secret** must be set, or the
+  invalidation step fails. Cache TTLs run to 24h, so without the invalidation a
+  successful deploy still serves the old page. Get the value from Terraform:
+
+  ```sh
+  gh secret set CLOUDFRONT_DISTRIBUTION_ID --body "$(terraform output -raw cloudfront_distribution_id)"
+  ```
+
+Terraform changes must be applied before merging a change that depends on them —
+the deploy role's permissions come from `jluszcz.tf`, so a workflow that uploads
+a new file or calls a new AWS API fails with `AccessDenied` until `terraform
+apply` has run. Note that `s3:PutObject` is scoped to `index.html` alone, so
+**adding any second file to the site requires a Terraform change first.**

--- a/index.html
+++ b/index.html
@@ -24,25 +24,14 @@
     <meta property="og:description" content="Jacob Luszcz's personal website" />
     <meta property="og:url" content="https://jluszcz.com" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://jluszcz.com/og-image.jpg" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
 
     <!-- Twitter Card meta tags -->
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Jacob Luszcz" />
     <meta name="twitter:description" content="Jacob Luszcz's personal website" />
-    <meta name="twitter:image" content="https://jluszcz.com/og-image.jpg" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#ffffff">
     <link rel="canonical" href="https://jluszcz.com">
-
-    <!-- Favicon and app manifest -->
-    <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="manifest" href="/site.webmanifest">
 
     <!-- JSON-LD structured data -->
     <script type="application/ld+json">

--- a/jluszcz.tf
+++ b/jluszcz.tf
@@ -243,9 +243,21 @@ resource "aws_iam_openid_connect_provider" "github" {
 }
 
 data "aws_iam_policy_document" "github" {
+  # Scoped to the single object the deploy writes. Adding any second file to the
+  # site therefore needs this widened and applied before the deploy will work.
   statement {
     actions   = ["s3:PutObject"]
     resources = ["${aws_s3_bucket.site.arn}/index.html"]
+  }
+
+  # Without an invalidation, a deploy is not live until the cache TTLs expire.
+  statement {
+    actions = [
+      "cloudfront:CreateInvalidation",
+      "cloudfront:GetInvalidation",
+    ]
+
+    resources = [aws_cloudfront_distribution.site.arn]
   }
 }
 
@@ -282,4 +294,10 @@ resource "aws_iam_role" "github" {
 resource "aws_iam_role_policy_attachment" "github" {
   role       = aws_iam_role.github.name
   policy_arn = aws_iam_policy.github.arn
+}
+
+# Set as the CLOUDFRONT_DISTRIBUTION_ID repository secret; the deploy workflow
+# reads it to invalidate the cache. See README.md → Deployment.
+output "cloudfront_distribution_id" {
+  value = aws_cloudfront_distribution.site.id
 }


### PR DESCRIPTION
Fixes the three live user-facing defects from the repo review. All three were verified against production before and are verified by the checks below.

## 1. Page served as `binary/octet-stream`

The minify step writes to `index.min` — no file extension — so `aws s3 cp` inferred no MIME type:

```
$ curl -sSI https://jluszcz.com/ | grep content-type
content-type: binary/octet-stream
```

It renders only because browsers sniff the bytes; adding a `nosniff` header would have broken the site outright. The upload now passes `--content-type "text/html; charset=utf-8"`.

## 2. No CloudFront invalidation

`default_ttl` is 24h and `min_ttl` is 1h, so a green deploy could keep serving the old page for a day. The workflow now creates an invalidation and **waits for it to complete**, so a passing check means the change is actually live.

- `jluszcz.tf` grants the deploy role `cloudfront:CreateInvalidation` + `GetInvalidation`, scoped to this distribution's ARN.
- The distribution ID comes from a new `CLOUDFRONT_DISTRIBUTION_ID` repository secret; `jluszcz.tf` exports `cloudfront_distribution_id` as an output to populate it.

## 3. Six assets that all 403

`index.html` referenced `favicon.ico`, `favicon-16x16.png`, `favicon-32x32.png`, `apple-touch-icon.png`, `site.webmanifest`, and `og-image.jpg`. None were ever in the repo, and all six returned 403 — a broken tab icon and broken link previews on every share.

```
favicon.ico              403
favicon-32x32.png        403
favicon-16x16.png        403
apple-touch-icon.png     403
site.webmanifest         403
og-image.jpg             403
```

Resolved by **removing the references** rather than adding the files, so the markup matches what is actually deployed. `twitter:card` drops from `summary_large_image` to `summary`, since that card type requires an image. Net effect: no more 403s, and link previews now show title + description with no image (previously they showed a broken image).

The IAM policy is deliberately left scoped to `index.html` alone — no second file is being uploaded, so widening it isn't needed. That constraint is now documented instead of being a trap.

## Docs

- Adds `CLAUDE.md` (the repo had none): the one-file/`AccessDenied` constraint, why 403 rather than 404 is the signal for a missing object, the explicit-content-type requirement, and the invalidation contract.
- `README.md` linked `.github/workflows/upload-to-s3.yml`, which does not exist — the file is `minify-and-upload-to-s3.yml`. Fixed, and the deploy section now documents the secret.

## ⚠️ Merge order

**`terraform apply` must run before this merges.** The deploy role has no CloudFront permissions today, so the invalidation step fails with `AccessDenied` otherwise. Then set the secret:

```sh
terraform apply
gh secret set CLOUDFRONT_DISTRIBUTION_ID --body "$(terraform output -raw cloudfront_distribution_id)"
```

## Verification

- `terraform fmt -check` and `terraform validate` — pass
- `actionlint` — pass
- `pre-commit run` on changed files — pass
- Minify step run locally: succeeds, and the output contains **zero** same-origin asset references
- AWS SSO was expired locally, so `terraform plan` was **not** run — the plan should be reviewed at apply time