### PR TITLE
fix: use SSE-S3 so CloudFront OAC can read the site object

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,23 @@ Because the bucket blocks public access and is readable only through
 CloudFront's OAC, a file `index.html` references but that was never uploaded
 returns **403, not 404**. Don't read that as a permissions bug.
 
+## The bucket must use SSE-S3
+
+`sse_algorithm` is `AES256`, and changing it to `aws:kms` takes the whole site
+down with `403 AccessDenied` (`server: AmazonS3`). CloudFront's OAC fetches the
+origin as the `cloudfront.amazonaws.com` service principal, which needs
+`kms:Decrypt` granted in the KMS *key policy*. With no `kms_master_key_id` S3
+uses the AWS-managed `aws/s3` key, whose policy cannot be edited — so OAC can
+never decrypt the object, no matter how correct the bucket policy looks.
+
+A customer-managed key would work, but it also needs `kms:GenerateDataKey` and
+`kms:Encrypt` added to the GitHub deploy role. The page is public by design, so
+KMS buys no confidentiality here.
+
+Changing this setting does **not** re-encrypt `index.html` — S3 default
+encryption only applies to new objects. After the apply, re-upload the object
+(pushing to `main` does it) or the old KMS-encrypted version keeps 403ing.
+
 ## Uploads must set `--content-type` explicitly
 
 The minified HTML is written to `index.min`, which has no file extension, so the

--- a/jluszcz.tf
+++ b/jluszcz.tf
@@ -37,14 +37,18 @@ resource "aws_s3_bucket_public_access_block" "site" {
   restrict_public_buckets = true
 }
 
+# Must stay SSE-S3. CloudFront's OAC reads the origin as the
+# cloudfront.amazonaws.com service principal, which needs kms:Decrypt granted in
+# the *key policy* — impossible for the AWS-managed aws/s3 key. Under aws:kms
+# every viewer request 403s. See CLAUDE.md → "The bucket must use SSE-S3".
 resource "aws_s3_bucket_server_side_encryption_configuration" "site" {
   bucket = aws_s3_bucket.site.id
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "aws:kms"
+      sse_algorithm = "AES256"
     }
-    bucket_key_enabled = true
+    blocked_encryption_types = ["SSE-C"]
   }
 }
 


### PR DESCRIPTION
## Problem

`https://jluszcz.com/` returned `403 AccessDenied` with `server: AmazonS3` — S3 refusing CloudFront's OAC-signed origin request, not CloudFront refusing the viewer.

The bucket defaulted to `sse_algorithm = "aws:kms"` with no `kms_master_key_id`, so S3 encrypted `index.html` under the **AWS-managed** key `alias/aws/s3`. CloudFront's OAC reads the origin as the `cloudfront.amazonaws.com` service principal, which needs `kms:Decrypt` granted in the KMS *key policy* — and an AWS-managed key's policy cannot be edited. So OAC could never decrypt the object, however correct the bucket policy looked.

## Evidence

Two objects uploaded to the real bucket, identical except encryption, both fetched through CloudFront:

| Object | Encryption | Result |
|---|---|---|
| `cftest-aes.html` | `AES256` | **200** |
| `cftest-kms.html` | `aws:kms` | **403 AccessDenied** |

Both test objects and all their versions have been deleted.

## Fix

`sse_algorithm` → `AES256`. The page is public by design, so KMS buys no confidentiality here; a customer-managed key would also require `kms:GenerateDataKey`/`kms:Encrypt` on the GitHub deploy role.

- `bucket_key_enabled` dropped — S3 Bucket Keys apply only to SSE-KMS.
- `blocked_encryption_types = ["SSE-C"]` added explicitly, so the apply doesn't silently drop the SSE-C block that was already on the bucket.

## Status

Already applied, per the apply-before-merge rule in `CLAUDE.md`:

- `terraform apply` — bucket default is now `AES256`, SSE-C still blocked.
- Changing default encryption does **not** re-encrypt existing objects, so `index.html` was re-copied in place as `AES256` (content-type preserved).
- CloudFront invalidated.
- Verified: `https://jluszcz.com/` and `https://www.jluszcz.com/` both return **200**, `text/html; charset=utf-8`, 3584 bytes.

`CLAUDE.md` gains a section documenting the constraint so this isn't reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)