### PR TITLE
fix: stop managing the account-wide OIDC provider from this repo

### DIFF
--- a/jluszcz.tf
+++ b/jluszcz.tf
@@ -238,12 +238,23 @@ resource "aws_route53_record" "atproto" {
   records = ["did=did:plc:${var.bluesky}"]
 }
 
-resource "aws_iam_openid_connect_provider" "github" {
+# There is one OIDC provider per AWS account, and it is owned by the
+# AmazonWebServices repo. Declaring it as a resource here made two Terraform
+# states manage the same object, so applying either one reverted the other's
+# changes. Every other project repo references it as a data source; this now
+# matches them.
+data "aws_iam_openid_connect_provider" "github" {
   url = "https://token.actions.githubusercontent.com"
+}
 
-  client_id_list = ["sts.amazonaws.com"]
+# Drops the resource from this state without touching the provider in AWS.
+# Delete this block once it has been applied — see the PR description.
+removed {
+  from = aws_iam_openid_connect_provider.github
 
-  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+  lifecycle {
+    destroy = false
+  }
 }
 
 data "aws_iam_policy_document" "github" {
@@ -279,7 +290,7 @@ resource "aws_iam_role" "github" {
       {
         Effect = "Allow",
         Principal = {
-          Federated = aws_iam_openid_connect_provider.github.arn
+          Federated = data.aws_iam_openid_connect_provider.github.arn
         },
         Action = "sts:AssumeRoleWithWebIdentity",
         Condition = {


### PR DESCRIPTION
Found by running `terraform plan` across every Terraform repo after AmazonWebServices#5 was applied. This was the only one that wasn't clean:

```
  # aws_iam_openid_connect_provider.github will be updated in-place
      ~ tags = {
          - "ManagedBy" = "terraform" -> null
          - "Repo"      = "AmazonWebServices" -> null
        }
```

There is **one OIDC provider per AWS account**, and it was declared as a `resource` both here and in AmazonWebServices — so two Terraform states managed the same object. Applying this repo strips the tags the other repo just set; applying that one puts them back. It ping-pongs forever.

`thumbprint_list` is the same conflict, latent: this repo still pinned `6938fd4d…` after AmazonWebServices#5 dropped it as dead weight (IAM has ignored supplied thumbprints since 2023).

**This didn't create the problem, it exposed it.** Before `default_tags` both configs produced byte-identical results, so the duplicate management was invisible.

### The fix

AmazonWebServices owns the provider. **LogStreamGC, LambdUpdate, mbtalerts, and JakeSky-rs all reference it as a `data` source** — this repo was the lone deviation, and now matches them. The `Federated = …` reference in the deploy role points at the data source instead; nothing about federated auth changes.

The `removed` block drops it from *this* state without touching the provider in AWS.

---

## ⚠️ What you need to do

**Order matters.** The `removed` block has to be applied before it can be deleted.

**1. Merge this PR.**

**2. Apply it:**

```sh
cd ~/Documents/Programs/jluszcz.com
git checkout main && git pull
. ./.envrc
terraform apply
```

**3. Check the plan output before typing `yes`.** It must say exactly this:

```
  # aws_iam_openid_connect_provider.github will no longer be managed by Terraform, but will not be destroyed

Plan: 0 to add, 0 to change, 0 to destroy.
```

plus a warning that Terraform "will discard its tracking information … but it will not delete them".

**If it says anything about *destroying* the OIDC provider, answer `no` and stop.** Destroying it breaks federated auth in every repo that deploys through GitHub Actions — this one, LogStreamGC, LambdUpdate, mbtalerts, and JakeSky-rs. The `lifecycle { destroy = false }` is what prevents that, so a destroy line would mean something is wrong with the block.

**4. Confirm the provider still exists:**

```sh
aws iam list-open-id-connect-providers
```

You should still see `…:oidc-provider/token.actions.githubusercontent.com`.

**5. Tell me it's applied**, and I'll open the one-line follow-up PR deleting the `removed` block. It is inert after this apply, but leaving it in the config indefinitely is clutter.

### Notes

- Until you apply, `terraform plan` here will keep proposing to strip those tags. That's expected and harmless.
- If you re-apply AmazonWebServices in the meantime, it re-tags the provider. Also harmless.
- `terraform validate` and `pre-commit run --all-files` pass, and the plan above is the actual output from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)